### PR TITLE
Fix cache metadata file discovery

### DIFF
--- a/.marbles/marbles.csv
+++ b/.marbles/marbles.csv
@@ -953,3 +953,6 @@ m-0f2b,scan unified-dashboard for cm gaps,evaluate /Users/reddot/Desktop/cursor/
 m-ef9c,detect typescript interface implementors beyond classes,implements/schema miss interfaces like DashboardPlugin and object-literal implementors in plugin-style codebases,open,1,pi,pi,,2026-03-11T04:52:38.906Z,2026-03-11T04:52:38.906Z,,
 m-4edd,reduce false unused entrypoints in callback/plugin systems,entrypoints flags exported render/helpers as unused when invoked through plugin registries or callback assembly,open,1,pi,pi,,2026-03-11T04:52:38.931Z,2026-03-11T04:52:38.931Z,,
 m-1a44,probe cm ergonomics with grep-like workflows,"test multi-query, exact/fuzzy, path scoping, and text-search friction on small and large repos",closed,1,pi,pi,pi,2026-03-11T04:57:57.043Z,2026-03-11T04:58:07.066Z,,
+m-fdb0,inspect github issue 14 cache bug,read issue details and reproduce the cache problem,closed,0,pi,pi,pi,2026-05-06T23:24:45.532Z,2026-05-06T23:28:11.763Z,,
+m-4387,verify cache issue 14 root cause,reproduce mismatch before fix and confirm fixed branch behavior,closed,0,pi,pi,pi,2026-05-06T23:30:04.838Z,2026-05-06T23:31:53.372Z,,
+m-a9cc,push cache fix pr for issue 14,push cache-fix and open github pr linked to issue 14,closed,0,pi,pi,pi,2026-05-06T23:34:30.747Z,2026-05-06T23:34:59.965Z,,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,10 +1,9 @@
-use crate::ignore;
 use crate::index::CodeIndex;
-use crate::indexer::matches_extension_filter;
+use crate::indexer::discover_indexable_files;
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
@@ -135,42 +134,16 @@ impl CacheManager {
         root: &Path,
         extensions: &[&str],
     ) -> Result<HashMap<PathBuf, FileMetadata>> {
-        use walkdir::WalkDir;
-
-        let mut metadata_map = HashMap::new();
-
-        for entry in WalkDir::new(root)
-            .follow_links(false)
+        let metadata = discover_indexable_files(root, extensions)?
             .into_iter()
-            .filter_entry(|e| {
-                if e.file_type().is_dir() {
-                    let dir_name = e.file_name().to_string_lossy();
-                    !ignore::is_ignored_dir(&dir_name)
-                } else {
-                    true
-                }
+            .filter_map(|path| {
+                Self::compute_file_metadata_single(&path)
+                    .ok()
+                    .map(|metadata| (path, metadata))
             })
-            .filter_map(|e| e.ok())
-        {
-            let path = entry.path();
-            if !path.is_file() {
-                continue;
-            }
+            .collect();
 
-            if matches_extension_filter(path, extensions) {
-                match Self::compute_file_metadata_single(path) {
-                    Ok(metadata) => {
-                        metadata_map.insert(path.to_path_buf(), metadata);
-                    }
-                    Err(_) => {
-                        // Skip files we can't read
-                        continue;
-                    }
-                }
-            }
-        }
-
-        Ok(metadata_map)
+        Ok(metadata)
     }
 
     /// Compute metadata for a single file (hash, size, mtime)
@@ -230,39 +203,17 @@ impl CacheManager {
         root: &Path,
         extensions: &[String],
     ) -> Result<HashMap<PathBuf, (u64, SystemTime)>> {
-        use walkdir::WalkDir;
-
-        let mut stats = HashMap::new();
-
-        for entry in WalkDir::new(root)
-            .follow_links(false)
+        let ext_refs: Vec<&str> = extensions.iter().map(String::as_str).collect();
+        let stats = discover_indexable_files(root, &ext_refs)?
             .into_iter()
-            .filter_entry(|e| {
-                if e.file_type().is_dir() {
-                    let dir_name = e.file_name().to_string_lossy();
-                    !ignore::is_ignored_dir(&dir_name)
-                } else {
-                    true
-                }
+            .filter_map(|path| {
+                fs::metadata(&path).ok().map(|metadata| {
+                    let size = metadata.len();
+                    let mtime = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+                    (path, (size, mtime))
+                })
             })
-            .filter_map(|e| e.ok())
-        {
-            let path = entry.path();
-            if !path.is_file() {
-                continue;
-            }
-
-            if matches_extension_filter(path, extensions) {
-                match fs::metadata(path) {
-                    Ok(metadata) => {
-                        let size = metadata.len();
-                        let mtime = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
-                        stats.insert(path.to_path_buf(), (size, mtime));
-                    }
-                    Err(_) => continue,
-                }
-            }
-        }
+            .collect();
 
         Ok(stats)
     }
@@ -328,6 +279,7 @@ impl CacheManager {
             }
         }
 
+        Self::sync_metadata_with_index(index, &mut file_metadata)?;
         Self::assert_metadata_consistency(index, &file_metadata)?;
 
         let cache_key = Self::compute_cache_key(root, extensions)?;
@@ -358,6 +310,26 @@ impl CacheManager {
         Self::ensure_gitignore(root, cache_dir)?;
 
         Ok(metadata)
+    }
+
+    fn sync_metadata_with_index(
+        index: &CodeIndex,
+        file_metadata: &mut HashMap<PathBuf, FileMetadata>,
+    ) -> Result<()> {
+        let indexed_paths: HashSet<PathBuf> = index.files().map(|file| file.path.clone()).collect();
+
+        file_metadata.retain(|path, _| indexed_paths.contains(path));
+
+        for file in index.files() {
+            if !file_metadata.contains_key(&file.path) {
+                file_metadata.insert(
+                    file.path.clone(),
+                    Self::compute_file_metadata_single(&file.path)?,
+                );
+            }
+        }
+
+        Ok(())
     }
 
     fn assert_metadata_consistency(
@@ -582,5 +554,30 @@ mod tests {
         let hash2 = CacheManager::compute_file_hash(&file_path).unwrap();
 
         assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_save_metadata_matches_indexer_gitignore_rules() {
+        let temp = TempDir::new().unwrap();
+        let cache_dir = TempDir::new().unwrap();
+        let root = temp.path();
+
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::write(root.join(".gitignore"), "ignored.rs\n").unwrap();
+        fs::write(root.join("included.rs"), "fn included() {}\n").unwrap();
+        fs::write(root.join("ignored.rs"), "fn ignored() {}\n").unwrap();
+
+        let index = crate::indexer::index_directory(root, &["rs"]).unwrap();
+        assert_eq!(index.total_files(), 1);
+
+        let metadata = CacheManager::save(&index, root, &["rs"], Some(cache_dir.path())).unwrap();
+
+        assert_eq!(metadata.file_metadata.len(), index.total_files());
+        assert!(metadata
+            .file_metadata
+            .contains_key(&root.join("included.rs")));
+        assert!(!metadata
+            .file_metadata
+            .contains_key(&root.join("ignored.rs")));
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -158,6 +158,31 @@ pub fn index_file(
     Ok(file_info)
 }
 
+pub fn discover_indexable_files(path: &Path, extensions: &[&str]) -> Result<Vec<PathBuf>> {
+    let walker = WalkBuilder::new(path)
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(false)
+        .git_exclude(false)
+        .filter_entry(|e| {
+            if e.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                let name = e.file_name().to_string_lossy();
+                !ignore::is_ignored_dir(&name)
+            } else {
+                true
+            }
+        })
+        .build();
+
+    Ok(walker
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
+        .filter(|e| matches_extension_filter(e.path(), extensions))
+        .map(|e| e.into_path())
+        .filter(|path| detect_language(path) != Language::Unknown)
+        .collect())
+}
+
 pub fn index_directory(path: &Path, extensions: &[&str]) -> Result<CodeIndex> {
     index_directory_with_progress(path, extensions, None)
 }
@@ -175,27 +200,7 @@ pub fn index_directory_with_progress(
         anyhow::bail!("Path is not a directory: {}", path.display());
     }
 
-    let walker = WalkBuilder::new(path)
-        .hidden(false)
-        .git_ignore(true)
-        .git_global(false)
-        .git_exclude(false)
-        .filter_entry(|e| {
-            if e.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
-                let name = e.file_name().to_string_lossy();
-                !ignore::is_ignored_dir(&name)
-            } else {
-                true
-            }
-        })
-        .build();
-
-    let entries: Vec<PathBuf> = walker
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
-        .filter(|e| matches_extension_filter(e.path(), extensions))
-        .map(|e| e.into_path())
-        .collect();
+    let entries = discover_indexable_files(path, extensions)?;
 
     let total_files = entries.len();
     let progress_wrapper = progress.map(|pb| {


### PR DESCRIPTION
## summary
- use the same file discovery path for indexing and cache metadata
- sync saved cache metadata to indexed files so gitignored/unindexed files cannot inflate counts
- add regression coverage for gitignored rust files

fixes #14

## verification
- cargo check
- cargo test
- cargo build
- reproduced pre-fix mismatch on 3bc867a (`expected 1, found 2`; cli fixture `expected 1500, found 1508`)
- fixed branch creates and loads cache cleanly on the same fixture