### PR TITLE
[codex] Support .mjs and .cjs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ cm since <last_release> --breaking # Breaking changes?
 | Language | Extensions | Extracts |
 |----------|------------|----------|
 | Python | .py | Functions, classes, methods, imports |
-| JavaScript | .js, .jsx | Functions, classes, methods, imports |
+| JavaScript | .js, .jsx, .mjs, .cjs | Functions, classes, methods, imports |
 | TypeScript | .ts, .tsx | Functions, classes, methods, interfaces, types, enums |
 | Rust | .rs | Functions, structs, impl blocks, traits, enums |
 | Java | .java | Classes, interfaces, methods, enums, javadoc |

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -272,6 +272,8 @@ mod tests {
     fn test_detect_language() {
         assert_eq!(detect_language(Path::new("test.py")), Language::Python);
         assert_eq!(detect_language(Path::new("test.js")), Language::JavaScript);
+        assert_eq!(detect_language(Path::new("test.mjs")), Language::JavaScript);
+        assert_eq!(detect_language(Path::new("test.cjs")), Language::JavaScript);
         assert_eq!(detect_language(Path::new("test.ts")), Language::TypeScript);
         assert_eq!(detect_language(Path::new("test.rs")), Language::Rust);
         assert_eq!(detect_language(Path::new("test.swift")), Language::Swift);
@@ -285,6 +287,8 @@ mod tests {
     fn test_matches_extension_filter() {
         assert!(matches_extension_filter(Path::new("test.rb"), &["rb"]));
         assert!(matches_extension_filter(Path::new("test.rbi"), &["rbi"]));
+        assert!(matches_extension_filter(Path::new("test.mjs"), &["mjs"]));
+        assert!(matches_extension_filter(Path::new("test.cjs"), &["cjs"]));
         assert!(matches_extension_filter(Path::new("Gemfile"), &["Gemfile"]));
         assert!(matches_extension_filter(Path::new("Gemfile"), &["gemfile"]));
         assert!(!matches_extension_filter(Path::new("Gemfile"), &["rb"]));

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,7 @@ TROUBLESHOOTING
 
 NO SYMBOLS FOUND?
   ✓ Fuzzy matching by default (matches more)
-  ✓ Check --extensions py,js,ts (default: py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md) — swift and ruby are INCLUDED by default
+  ✓ Check --extensions py,js,ts (default: py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md) — swift and ruby are INCLUDED by default
   ✓ Verify file encoding is UTF-8
   ✓ Run: cm stats . (to see what's indexed)
 
@@ -333,7 +333,7 @@ TYPICAL WORKFLOW:
         /// Comma-separated file extensions to include (e.g., 'py,js,rs,go,c,h,rb,md')
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -385,7 +385,7 @@ TYPICAL WORKFLOW:
         /// Comma-separated file extensions to include (e.g., 'py,js,rs,go,c,h,rb,md')
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -490,7 +490,7 @@ WHEN TO USE:
         /// Comma-separated file extensions to include (e.g., 'py,js,rs,go,c,h,rb,md')
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -658,7 +658,7 @@ WHEN TO USE:
         /// Comma-separated file extensions to include (e.g., 'py,js,rs,go,c,h,rb,md')
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -704,7 +704,7 @@ NOTE: For normal usage, use 'cm stats' or 'cm map' instead")]
         /// Comma-separated file extensions to include (e.g., 'py,js,rs,go,c,h,rb,md')
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
     },
@@ -756,7 +756,7 @@ WHEN TO USE:
         /// Comma-separated file extensions to include (e.g., 'py,js,rs,go,c,h,rb,md')
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -806,7 +806,7 @@ TYPICAL WORKFLOW:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -862,7 +862,7 @@ TYPICAL WORKFLOW:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -921,7 +921,7 @@ TYPICAL WORKFLOW:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -970,7 +970,7 @@ TYPICAL WORKFLOW:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -1032,7 +1032,7 @@ WHEN TO USE:
         /// Comma-separated file extensions to include (e.g., 'py,js,rs,go,c,h,rb,md')
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -1088,7 +1088,7 @@ WHEN TO USE:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -1154,7 +1154,7 @@ WHEN TO USE:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -1210,7 +1210,7 @@ TIP: Run this after changing a function signature"
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -1258,7 +1258,7 @@ TYPICAL WORKFLOW:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -1387,7 +1387,7 @@ WHEN TO USE:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -1457,7 +1457,7 @@ WHEN TO USE:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -1517,7 +1517,7 @@ WHEN TO USE:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -1578,7 +1578,7 @@ TYPICAL WORKFLOW:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 
@@ -1629,7 +1629,7 @@ TYPICAL WORKFLOW:
         /// Comma-separated file extensions to include
         #[arg(
             long,
-            default_value = "py,js,ts,jsx,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
+            default_value = "py,js,jsx,mjs,cjs,ts,tsx,rs,java,go,c,h,swift,rb,rbi,rake,gemspec,ru,gemfile,rakefile,capfile,guardfile,thorfile,podfile,fastfile,appraisals,dangerfile,md"
         )]
         extensions: String,
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -20,7 +20,7 @@ impl Language {
     pub fn from_extension(ext: &str) -> Self {
         match ext.to_ascii_lowercase().as_str() {
             "py" => Language::Python,
-            "js" | "jsx" => Language::JavaScript,
+            "js" | "jsx" | "mjs" | "cjs" => Language::JavaScript,
             "ts" | "tsx" => Language::TypeScript,
             "rs" => Language::Rust,
             "java" => Language::Java,


### PR DESCRIPTION
## Summary

- recognize `.mjs` and `.cjs` as JavaScript files
- include both extensions in CLI defaults across analysis commands
- document the supported Node.js JavaScript extensions
- add regression coverage for language detection and extension filtering

## Why

CodeMapper's JavaScript parser already supports ECMAScript module and CommonJS syntax, but extension detection only accepted `.js` and `.jsx`. As a result, Node.js projects using explicit `.mjs` or `.cjs` extensions were skipped or rejected as unsupported file types.

## Validation

- `cargo fmt -- --check`
- `cargo test` (89 passed)
- release CLI inspection of a real `.mjs` file
- release CLI project map indexing two `.mjs` files as JavaScript
